### PR TITLE
Updated Web3.js Deno to 1.6.1

### DIFF
--- a/types/buffer.d.ts
+++ b/types/buffer.d.ts
@@ -368,7 +368,7 @@ declare module 'buffer' {
              * @param [encoding='utf8'] If `string` is a string, this is its encoding.
              * @return The number of bytes contained within `string`.
              */
-            byteLength(string: string | NodeJS.ArrayBufferView | ArrayBuffer | SharedArrayBuffer, encoding?: BufferEncoding): number;
+            byteLength(string: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, encoding?: BufferEncoding): number;
             /**
              * Returns a new `Buffer` which is the result of concatenating all the `Buffer`instances in the `list` together.
              *

--- a/types/http.d.ts
+++ b/types/http.d.ts
@@ -1,4 +1,4 @@
-interface AgentOptions {
+export interface AgentOptions {
     /**
      * Keep sockets around in a pool to be used by other requests in the future. Default = false
      */
@@ -31,7 +31,7 @@ interface AgentOptions {
     scheduling?: 'fifo' | 'lifo' | undefined;
 }
 
-class Agent {
+export class Agent {
     /**
      * By default set to 256\. For agents with `keepAlive` enabled, this
      * sets the maximum number of sockets that will be left open in the free


### PR DESCRIPTION

## Web3 Update
This is an automated request made by the web3-deno-generator and contains updated parts of the Web3.js.

## Versions
Version of official Web3.js: `1.6.1`
Version of next deno.land release: `v0.8.5`

## Test Results
```
running 1 test from file:///Users/ntrotner/git/web3-deno-generator/web3/tests/bzz_test.ts
test setProvider ... [0m[32mok[0m [0m[38;5;8m(9ms)[0m
running 11 tests from file:///Users/ntrotner/git/web3-deno-generator/web3/tests/eth_test.ts
test setProvider ... [0m[32mok[0m [0m[38;5;8m(10ms)[0m
test providers ... [0m[32mok[0m [0m[38;5;8m(7ms)[0m
test defaults ... [0m[32mok[0m [0m[38;5;8m(7ms)[0m
test getAccounts ... [0m[32mok[0m [0m[38;5;8m(722ms)[0m
test getBalance ... [0m[32mok[0m [0m[38;5;8m(745ms)[0m
test getBlock ... [0m[32mok[0m [0m[38;5;8m(810ms)[0m
test getTransaction ... [0m[32mok[0m [0m[38;5;8m(711ms)[0m
test estimateGas ... [0m[32mok[0m [0m[38;5;8m(716ms)[0m
test read and execute read contract ... [0m[32mok[0m [0m[38;5;8m(718ms)[0m
test toIBAN ... [0m[32mok[0m [0m[38;5;8m(9ms)[0m
test toABI ... [0m[32mok[0m [0m[38;5;8m(10ms)[0m
running 2 tests from file:///Users/ntrotner/git/web3-deno-generator/web3/tests/shh_test.ts
test setProvider ... [0m[32mok[0m [0m[38;5;8m(12ms)[0m
test getId ... [0m[32mok[0m [0m[38;5;8m(715ms)[0m

test result: [0m[32mok[0m. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out [0m[38;5;8m(9155ms)[0m
```